### PR TITLE
Add repository URL to package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Package license: MIT
 
 Summary: Runtime typing introspection tools
 
+Development: https://github.com/pydantic/typing-inspection
+
 Current build status
 ====================
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -35,6 +35,7 @@ test:
 about:
   summary: Runtime typing introspection tools
   home: https://github.com/pydantic/typing-inspection
+  dev_url: https://github.com/pydantic/typing-inspection
   license: MIT
   license_file: LICENSE
 


### PR DESCRIPTION
We would like to have automated checks on build packages and for those the correct repository URL would be helpful. As these checks run on build packages I also increased the build number.

cc @xhochy